### PR TITLE
Replaces tempdir with tempfile because of deprecation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name        = "brev"
 description = "helpers for quick and dirty scripting"
-version     = "0.1.12"
+version     = "0.2.0"
 authors     = ["Casey Rodarmor <casey@rodarmor.com>"]
 license     = "CC0-1.0"
 repository  = "https://github.com/casey/brev"
 
 [dependencies]
 glob    = "0.3"
-tempdir = "0.3"
+tempfile = "3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 extern crate glob;
-extern crate tempdir;
+extern crate tempfile;
 
 use std::io::prelude::*;
 use std::{env, fmt, io, process, path, fs, iter};
@@ -33,8 +33,8 @@ pub fn empty<T, C: iter::FromIterator<T>>() -> C {
   iter::empty().collect()
 }
 
-pub fn tmpdir<S: AsRef<str>>(prefix: S) -> (tempdir::TempDir, String) {
-  let tmp = tempdir::TempDir::new(prefix.as_ref()).unwrap_or_else(|err| panic!("tmpdir: failed to create temporary directory: {}", err));
+pub fn tmpdir<S: AsRef<str>>(prefix: S) -> (tempfile::TempDir, String) {
+  let tmp = tempfile::Builder::new().prefix(prefix.as_ref()).tempdir().unwrap_or_else(|err| panic!("tmpdir: failed to create temporary directory: {}", err));
   let path = tmp.path().to_str().unwrap_or_else(|| panic!("tmpdir: path was not valid UTF-8")).to_owned();
   return (tmp, path);
 }


### PR DESCRIPTION
Hey, 

I'm working on getting `just` into debian and depending on `tempdir` would be a blocker for that. So here is a PR to remove `tempdir` in favour of `tempfile`.

Thanks